### PR TITLE
Temperatures below 0°C fixed

### DIFF
--- a/firmware/SparkFunRHT03.cpp
+++ b/firmware/SparkFunRHT03.cpp
@@ -97,7 +97,15 @@ int RHT03::update()
     if (checksum(dataBytes[CHECKSUM], dataBytes, 4))
     {
         _humidity = ((uint16_t) dataBytes[HUMIDITY_H] << 8) | dataBytes[HUMIDITY_L];
+        if(_humidity & 0x8000) {
+            _humidity -= 0x7FFF;
+            _humidity *= -1;
+        }
         _temperature = ((uint16_t) dataBytes[TEMP_H] << 8) | dataBytes[TEMP_L];
+        if(_temperature & 0x8000) {
+            _temperature -= 0x7FFF;
+            _temperature *= -1;
+        }        
         return 1;
     }
     else


### PR DESCRIPTION
Temperatures below the freezing point would result in temperatures above 3276.7°C, due to the overflow not getting handled. Solution is to subtract 32767 and then reverse the sign.

I did the same for the humidity, just in case.
